### PR TITLE
Pulumi preview permission fix

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,11 +1,12 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.5-59-g6bcb72f
+_commit: v0.0.5-61-g1c5783e
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: Managing an AWS Organization
 python_ci_versions:
 - 3.12.7
 python_version: 3.12.7
 repo_name: copier-aws-organization
+repo_org_name: LabAutomationAndScreening
 ssh_port_number: 54184
 template_uses_pulumi: true
 template_uses_python: true

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.5-61-g1c5783e
+_commit: v0.0.5-62-gebf75db
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: Managing an AWS Organization
 python_ci_versions:

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.5-57-g045b3f3
+_commit: v0.0.5-59-g6bcb72f
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: Managing an AWS Organization
 python_ci_versions:

--- a/.devcontainer/install-ci-tooling.sh
+++ b/.devcontainer/install-ci-tooling.sh
@@ -2,7 +2,7 @@
 # can pass in the full major.minor.patch version of python as an optional argument
 set -ex
 
-curl -LsSf https://astral.sh/uv/0.5.28/install.sh | sh
+curl -LsSf https://astral.sh/uv/0.6.3/install.sh | sh
 uv --version
 # TODO: add uv autocompletion to the shell https://docs.astral.sh/uv/getting-started/installation/#shell-autocompletion
 
@@ -15,8 +15,8 @@ input="${1:-$default_version}"
 export UV_PYTHON="$input"
 export UV_PYTHON_PREFERENCE=only-system
 
-uv tool install 'copier==9.4.1' --with 'copier-templates-extensions==0.3.0'
+uv tool install 'copier==9.5.0' --with 'copier-templates-extensions==0.3.0'
 
-uv tool install 'pre-commit==4.0.1'
+uv tool install 'pre-commit==4.1.0'
 
 uv tool list

--- a/.github/actions/install_deps_uv/install-ci-tooling.ps1
+++ b/.github/actions/install_deps_uv/install-ci-tooling.ps1
@@ -3,7 +3,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-irm https://astral.sh/uv/0.5.28/install.ps1 | iex
+irm https://astral.sh/uv/0.6.3/install.ps1 | iex
 
 # Add uv to path (in github runner)
 $env:Path = "C:\Users\runneradmin\.local\bin;$env:Path"
@@ -24,8 +24,8 @@ if ($args.Count -eq 0) {
 $env:UV_PYTHON = "$input"
 $env:UV_PYTHON_PREFERENCE="only-system"
 
-& uv tool install 'copier==9.4.1' --with 'copier-templates-extensions==0.3.0'
+& uv tool install 'copier==9.5.0' --with 'copier-templates-extensions==0.3.0'
 
-& uv tool install 'pre-commit==4.0.1'
+& uv tool install 'pre-commit==4.1.0'
 
 & uv tool list

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
 
 # Reformatting (should generally come before any file format or other checks, because reformatting can change things)
 -   repo: https://github.com/crate-ci/typos
-    rev: e59f226fadcb05a1440bd8b35ee994a9d21bf03b  # frozen: typos-dict-v0.12.4
+    rev: 9a11895dc3c5e1f4123ec841d08182d704593f6d  # frozen: v1.30.0
     hooks:
       - id: typos
 -   repo: https://github.com/pre-commit/pre-commit-hooks
@@ -162,7 +162,7 @@ repos:
         description: Runs hadolint to lint Dockerfiles
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 871f3bcae4fe473cd7109c3a068db975dc035e3b  # frozen: v0.9.4
+    rev: 2c8dce6094fa2b4b668e74f694ca63ceffd38614  # frozen: v0.9.9
     hooks:
     -   id: ruff
         name: ruff-src

--- a/README.md
+++ b/README.md
@@ -4,12 +4,17 @@
 [![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://www.github.com/LabAutomationAndScreening/copier-aws-organization)
 
 
+# Usage
+To create a new repository using this template:
+1. Install `copier` and `copier-templates-extensions`. An easy way to do that is to copy the `.devcontainer/install-ci-tooling.sh` script in this repository into your new repo and then run it.
+2. Run copier to instantiate the template: `copier copy --trust gh:LabAutomationAndScreening/copier-aws-organization.git`
+3. Run `uv lock` to generate the lock file
+4. Commit the changes
+5. Rebuild your new devcontainer
 
 
 
-
-
-
+# Development
 
 
 ## Updating from the template

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
+[![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-black.json)](https://github.com/copier-org/copier)
+[![Actions status](https://www.github.com/LabAutomationAndScreening/copier-aws-organization/actions/workflows/ci.yaml/badge.svg?branch=main)](https://www.github.com/LabAutomationAndScreening/copier-aws-organization/actions)
+[![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://www.github.com/LabAutomationAndScreening/copier-aws-organization)
+
 
 
 

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -10,16 +10,16 @@ class ContextUpdater(ContextHook):
 
     @override
     def hook(self, context: dict[Any, Any]) -> dict[Any, Any]:
-        context["uv_version"] = "0.5.28"
-        context["pre_commit_version"] = "4.0.1"
-        context["pyright_version"] = "1.1.394"
+        context["uv_version"] = "0.6.3"
+        context["pre_commit_version"] = "4.1.0"
+        context["pyright_version"] = "1.1.396"
         context["pytest_version"] = "8.3.4"
         context["pytest_randomly_version"] = "3.16.0"
         context["pytest_cov_version"] = "6.0.0"
-        context["copier_version"] = "9.4.1"
+        context["copier_version"] = "9.5.0"
         context["copier_templates_extension_version"] = "0.3.0"
         context["sphinx_version"] = "8.1.3"
-        context["pulumi_version"] = "3.149.0"
+        context["pulumi_version"] = "3.153.1"
         context["pulumi_aws_version"] = "6.67.0"
         context["pulumi_aws_native_version"] = "1.25.0"
         context["pulumi_command_version"] = "1.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ dependencies = [
     "pytest>=8.3.4",
     "pytest-cov>=6.0.0",
     "pytest-randomly>=3.16.0",
-    "pyright[nodejs]>=1.1.394",
-    "copier>=9.4.1",
+    "pyright[nodejs]>=1.1.396",
+    "copier>=9.5.0",
     "copier-templates-extensions>=0.3.0"
 
     # Specific to this template

--- a/template/.github/actions/install_deps_uv/install-ci-tooling.ps1
+++ b/template/.github/actions/install_deps_uv/install-ci-tooling.ps1
@@ -3,7 +3,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-irm https://astral.sh/uv/0.5.28/install.ps1 | iex
+irm https://astral.sh/uv/0.6.3/install.ps1 | iex
 
 # Add uv to path (in github runner)
 $env:Path = "C:\Users\runneradmin\.local\bin;$env:Path"
@@ -24,8 +24,8 @@ if ($args.Count -eq 0) {
 $env:UV_PYTHON = "$input"
 $env:UV_PYTHON_PREFERENCE="only-system"
 
-& uv tool install 'copier==9.4.1' --with 'copier-templates-extensions==0.3.0'
+& uv tool install 'copier==9.5.0' --with 'copier-templates-extensions==0.3.0'
 
-& uv tool install 'pre-commit==4.0.1'
+& uv tool install 'pre-commit==4.1.0'
 
 & uv tool list

--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
 
 # Reformatting (should generally come before any file format or other checks, because reformatting can change things)
 -   repo: https://github.com/crate-ci/typos
-    rev: e59f226fadcb05a1440bd8b35ee994a9d21bf03b  # frozen: typos-dict-v0.12.4
+    rev: 9a11895dc3c5e1f4123ec841d08182d704593f6d  # frozen: v1.30.0
     hooks:
       - id: typos
 -   repo: https://github.com/pre-commit/pre-commit-hooks
@@ -162,7 +162,7 @@ repos:
         description: Runs hadolint to lint Dockerfiles
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 871f3bcae4fe473cd7109c3a068db975dc035e3b  # frozen: v0.9.4
+    rev: 2c8dce6094fa2b4b668e74f694ca63ceffd38614  # frozen: v0.9.9
     hooks:
     -   id: ruff
         name: ruff-src

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -1,9 +1,13 @@
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
+[![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-black.json)](https://github.com/copier-org/copier)
+[![Actions status](https://www.github.com/LabAutomationAndScreening/copier-aws-organization/actions/workflows/ci.yaml/badge.svg?branch=main)](https://www.github.com/LabAutomationAndScreening/copier-aws-organization/actions)
+[![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://www.github.com/LabAutomationAndScreening/copier-aws-organization)
+
+
 
 
 # Using Pulumi
 Run a Pulumi Preview: `uv run python -m aws_organization.pulumi_deploy --stack={{ pulumi_stack_name }}`
-
 
 
 

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -2,7 +2,7 @@
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![Checked with pyright](https://microsoft.github.io/pyright/img/pyright_badge.svg)](https://microsoft.github.io/pyright/)
-[![Actions status](https://www.github.com/{% endraw %}{{ repo_org_name }}/{{ repo_name }}{% raw %}/actions/workflows/ci.yaml/badge.svg?branch=main)](https://www.github.com/LabAutomationAndScreening/copier-aws-organization/actions)
+[![Actions status](https://www.github.com/{% endraw %}{{ repo_org_name }}/{{ repo_name }}{% raw %}/actions/workflows/ci.yaml/badge.svg?branch=main)](https://www.github.com/{% endraw %}{{ repo_org_name }}/{{ repo_name }}{% raw %}/actions)
 [![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://www.github.com/{% endraw %}{{ repo_org_name }}/{{ repo_name }}{% raw %})
 
 

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -1,4 +1,4 @@
-[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
+{% raw %}[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-black.json)](https://github.com/copier-org/copier)
 [![Actions status](https://www.github.com/LabAutomationAndScreening/copier-aws-organization/actions/workflows/ci.yaml/badge.svg?branch=main)](https://www.github.com/LabAutomationAndScreening/copier-aws-organization/actions)
 [![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://www.github.com/LabAutomationAndScreening/copier-aws-organization)
@@ -16,6 +16,8 @@ To create a new repository using this template:
 
 # Development
 
+## Using Pulumi
+Run a Pulumi Preview: `uv run python -m aws_organization.pulumi_deploy --stack={% endraw %}{{ pulumi_stack_name }}{% raw %}`
 
 ## Updating from the template
 This repository uses a copier template. To pull in the latest updates from the template, use the command:

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -21,4 +21,4 @@ Run a Pulumi Preview: `uv run python -m aws_organization.pulumi_deploy --stack={
 
 ## Updating from the template
 This repository uses a copier template. To pull in the latest updates from the template, use the command:
-`copier update --trust --conflict rej --defaults`
+`copier update --trust --conflict rej --defaults`{% endraw %}

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -4,13 +4,17 @@
 [![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://www.github.com/LabAutomationAndScreening/copier-aws-organization)
 
 
+# Usage
+To create a new repository using this template:
+1. Install `copier` and `copier-templates-extensions`. An easy way to do that is to copy the `.devcontainer/install-ci-tooling.sh` script in this repository into your new repo and then run it.
+2. Run copier to instantiate the template: `copier copy --trust gh:LabAutomationAndScreening/copier-aws-organization.git`
+3. Run `uv lock` to generate the lock file
+4. Commit the changes
+5. Rebuild your new devcontainer
 
 
-# Using Pulumi
-Run a Pulumi Preview: `uv run python -m aws_organization.pulumi_deploy --stack={{ pulumi_stack_name }}`
 
-
-
+# Development
 
 
 ## Updating from the template

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -1,16 +1,10 @@
 {% raw %}[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-black.json)](https://github.com/copier-org/copier)
-[![Actions status](https://www.github.com/LabAutomationAndScreening/copier-aws-organization/actions/workflows/ci.yaml/badge.svg?branch=main)](https://www.github.com/LabAutomationAndScreening/copier-aws-organization/actions)
-[![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://www.github.com/LabAutomationAndScreening/copier-aws-organization)
+[![Actions status](https://www.github.com/{% endraw %}{{ repo_org_name }}/{{ repo_name }}{% raw %}/actions/workflows/ci.yaml/badge.svg?branch=main)](https://www.github.com/LabAutomationAndScreening/copier-aws-organization/actions)
+[![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://www.github.com/{% endraw %}{{ repo_org_name }}/{{ repo_name }}{% raw %})
 
 
 # Usage
-To create a new repository using this template:
-1. Install `copier` and `copier-templates-extensions`. An easy way to do that is to copy the `.devcontainer/install-ci-tooling.sh` script in this repository into your new repo and then run it.
-2. Run copier to instantiate the template: `copier copy --trust gh:LabAutomationAndScreening/copier-aws-organization.git`
-3. Run `uv lock` to generate the lock file
-4. Commit the changes
-5. Rebuild your new devcontainer
 
 
 

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -1,5 +1,7 @@
 {% raw %}[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
-[![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-black.json)](https://github.com/copier-org/copier)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
+[![Checked with pyright](https://microsoft.github.io/pyright/img/pyright_badge.svg)](https://microsoft.github.io/pyright/)
 [![Actions status](https://www.github.com/{% endraw %}{{ repo_org_name }}/{{ repo_name }}{% raw %}/actions/workflows/ci.yaml/badge.svg?branch=main)](https://www.github.com/LabAutomationAndScreening/copier-aws-organization/actions)
 [![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://www.github.com/{% endraw %}{{ repo_org_name }}/{{ repo_name }}{% raw %})
 

--- a/template/pulumi-bootstrap.yaml.jinja
+++ b/template/pulumi-bootstrap.yaml.jinja
@@ -133,13 +133,10 @@ Resources:
       Value:
         Ref: InfraStateBucket
       Tags:
-        - Key: "iac-git-repository-url"
-          Value:
-            Ref: GitRepositoryUrl
-        - Key: "managed-via-iac-by"
-          Value: "cloudformation"
-        - Key: "cloudformation-yaml-file"
-          Value: "pulumi-bootstrap.yaml"
+        iac-git-repository-url:
+          Ref: GitRepositoryUrl
+        managed-via-iac-by: "cloudformation"
+        cloudformation-yaml-file: "pulumi-bootstrap.yaml"
 
   InfraStateKMSKey:
     Type: "AWS::KMS::Key"
@@ -199,13 +196,10 @@ Resources:
           - InfraStateKMSKey
           - Arn
       Tags:
-        - Key: "iac-git-repository-url"
-          Value:
-            Ref: GitRepositoryUrl
-        - Key: "managed-via-iac-by"
-          Value: "cloudformation"
-        - Key: "cloudformation-yaml-file"
-          Value: "pulumi-bootstrap.yaml"
+        iac-git-repository-url:
+          Ref: GitRepositoryUrl
+        managed-via-iac-by: "cloudformation"
+        cloudformation-yaml-file: "pulumi-bootstrap.yaml"
 
   GitHubOIDCProvider:
     Type: "AWS::IAM::OIDCProvider"

--- a/template/pulumi-bootstrap.yaml.jinja
+++ b/template/pulumi-bootstrap.yaml.jinja
@@ -1,12 +1,18 @@
-AWSTemplateFormatVersion: "2010-09-09"
+{% raw %}AWSTemplateFormatVersion: "2010-09-09"
 Description: "CloudFormation template to create IAM Roles, an S3 bucket, and an OIDC provider for GitHub."
 Parameters:
   RepoName:
     Type: String
     Description: "The GitHub repository name in the format 'owner/repo'."
+    Default: {% endraw %}{{ repo_org_name }}/{{ repo_name }}{% raw %}
   OrganizationId:
     Type: String
     Description: "The AWS Organization ID."
+  GitRepositoryUrl:
+    Type: String
+    Default: "https://github.com/{% endraw %}{{ repo_org_name }}/{{ repo_name }}{% raw %}"
+    Description: "The URL of the GitHub repository."
+
 Resources:
   OrgRootInfraDeployRole:
     Type: "AWS::IAM::Role"
@@ -27,6 +33,14 @@ Resources:
                 token.actions.githubusercontent.com:aud: "sts.amazonaws.com"
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/AdministratorAccess"
+      Tags:
+        - Key: "iac-git-repository-url"
+          Value:
+            Ref: GitRepositoryUrl
+        - Key: "managed-via-iac-by"
+          Value: "cloudformation"
+        - Key: "cloudformation-yaml-file"
+          Value: "pulumi-bootstrap.yaml"
 
   OrgRootInfraPreviewRole:
     Type: "AWS::IAM::Role"
@@ -61,6 +75,38 @@ Resources:
                   Fn::GetAtt:
                     - InfraStateKMSKey
                     - Arn
+        - PolicyName: "S3BucketAccessPolicy"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: "CreateMetadataAndLocks"
+                Effect: Allow
+                Action:
+                  - "s3:PutObject"
+                Resource:
+                  Fn::Sub:
+                    - "arn:aws:s3:::${BucketName}/*"
+                    - BucketName:
+                        Ref: InfraStateBucket
+              - Sid: "RemoveLock"
+                Effect: Allow
+                Action:
+                  - "s3:DeleteObject"
+                  - "s3:DeleteObjectVersion"
+                Resource:
+                  Fn::Sub:
+                    - "arn:aws:s3:::${BucketName}/*/.pulumi/locks/*.json"
+                    - BucketName:
+                        Ref: InfraStateBucket
+      Tags:
+        - Key: "iac-git-repository-url"
+          Value:
+            Ref: GitRepositoryUrl
+        - Key: "managed-via-iac-by"
+          Value: "cloudformation"
+        - Key: "cloudformation-yaml-file"
+          Value: "pulumi-bootstrap.yaml"
+
   InfraStateBucket:
     Type: "AWS::S3::Bucket"
     Properties:
@@ -70,6 +116,15 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: "AES256"
+      Tags:
+        - Key: "iac-git-repository-url"
+          Value:
+            Ref: GitRepositoryUrl
+        - Key: "managed-via-iac-by"
+          Value: "cloudformation"
+        - Key: "cloudformation-yaml-file"
+          Value: "pulumi-bootstrap.yaml"
+
   InfraStateBucketNameParameter:
     Type: "AWS::SSM::Parameter"
     Properties:
@@ -77,6 +132,15 @@ Resources:
       Type: "String"
       Value:
         Ref: InfraStateBucket
+      Tags:
+        - Key: "iac-git-repository-url"
+          Value:
+            Ref: GitRepositoryUrl
+        - Key: "managed-via-iac-by"
+          Value: "cloudformation"
+        - Key: "cloudformation-yaml-file"
+          Value: "pulumi-bootstrap.yaml"
+
   InfraStateKMSKey:
     Type: "AWS::KMS::Key"
     Properties:
@@ -109,12 +173,22 @@ Resources:
                   Ref: OrganizationId
       Enabled: true
       KeyUsage: "ENCRYPT_DECRYPT"
+      Tags:
+        - Key: "iac-git-repository-url"
+          Value:
+            Ref: GitRepositoryUrl
+        - Key: "managed-via-iac-by"
+          Value: "cloudformation"
+        - Key: "cloudformation-yaml-file"
+          Value: "pulumi-bootstrap.yaml"
+
   InfraStateKMSKeyAlias:
     Type: "AWS::KMS::Alias"
     Properties:
       AliasName: "alias/org-wide-infra-state"
       TargetKeyId:
         Ref: InfraStateKMSKey
+
   InfraStateKMSKeyArnParameter:
     Type: "AWS::SSM::Parameter"
     Properties:
@@ -124,6 +198,15 @@ Resources:
         Fn::GetAtt:
           - InfraStateKMSKey
           - Arn
+      Tags:
+        - Key: "iac-git-repository-url"
+          Value:
+            Ref: GitRepositoryUrl
+        - Key: "managed-via-iac-by"
+          Value: "cloudformation"
+        - Key: "cloudformation-yaml-file"
+          Value: "pulumi-bootstrap.yaml"
+
   GitHubOIDCProvider:
     Type: "AWS::IAM::OIDCProvider"
     Properties:
@@ -131,13 +214,4 @@ Resources:
       ClientIdList:
         - "sts.amazonaws.com"
       ThumbprintList:
-        - "6938fd4d98bab03faadb97b34396831e3780aea1"
-Outputs:
-  OrgRootInfraDeployRole:
-    Description: "IAM Role with AdministratorAccess permissions."
-    Value:
-      Ref: OrgRootInfraDeployRole
-  InfraStateBucket:
-    Description: "S3 bucket created for infrastructure state."
-    Value:
-      Ref: InfraStateBucket
+        - "6938fd4d98bab03faadb97b34396831e3780aea1"{% endraw %}

--- a/uv.lock
+++ b/uv.lock
@@ -21,7 +21,7 @@ wheels = [
 
 [[package]]
 name = "copier"
-version = "9.4.1"
+version = "9.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama" },
@@ -31,15 +31,16 @@ dependencies = [
     { name = "jinja2-ansible-filters" },
     { name = "packaging" },
     { name = "pathspec" },
+    { name = "platformdirs" },
     { name = "plumbum" },
     { name = "pydantic" },
     { name = "pygments" },
     { name = "pyyaml" },
     { name = "questionary" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/84/b99005e18cb07986a9fa1c1314c9bb461851dc115ab24d3d9ac668daad7f/copier-9.4.1.tar.gz", hash = "sha256:cc81d8204cb17fbc8c4a14996a8ce764166c34c77236de38cfbeb960c887b68f", size = 41510 }
+sdist = { url = "https://files.pythonhosted.org/packages/44/49/1a43fade92e3af317393943ac005ed1b4094a88e999acda34f3d0e27aef8/copier-9.5.0.tar.gz", hash = "sha256:db7311075176376ee746fe610ffb5b27db7ac755585d6149894f677ffbce127d", size = 44422 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/96/5e8edaef8be1bd0a17943e6a011d4fc311f340e45733ef910a6f0b688587/copier-9.4.1-py3-none-any.whl", hash = "sha256:863385b7ba8a9090c832cd12ca072dba9153397dbe7c5f337bf8c3d8859efa32", size = 43188 },
+    { url = "https://files.pythonhosted.org/packages/c0/5d/6b8d8816cb49c5ff7a588324210a9c953c1f903278fa99268ace66868689/copier-9.5.0-py3-none-any.whl", hash = "sha256:d7d9851649ad71518f8e868ab761362af0ee9008025a3f85647e9724983cf540", size = 47543 },
 ]
 
 [[package]]
@@ -57,9 +58,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "copier", specifier = ">=9.4.1" },
+    { name = "copier", specifier = ">=9.5.0" },
     { name = "copier-templates-extensions", specifier = ">=0.3.0" },
-    { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.394" },
+    { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.396" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-randomly", specifier = ">=3.16.0" },
@@ -251,6 +252,15 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.3.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/fc/128cc9cb8f03208bdbf93d3aa862e16d376844a14f9a0ce5cf4507372de4/platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907", size = 21302 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/a6/bc1012356d8ece4d66dd75c4b9fc6c1f6650ddd5991e421177d9f8f671be/platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb", size = 18439 },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -347,15 +357,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.394"
+version = "1.1.396"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/e4/79f4d8a342eed6790fdebdb500e95062f319ee3d7d75ae27304ff995ae8c/pyright-1.1.394.tar.gz", hash = "sha256:56f2a3ab88c5214a451eb71d8f2792b7700434f841ea219119ade7f42ca93608", size = 3809348 }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/73/f20cb1dea1bdc1774e7f860fb69dc0718c7d8dea854a345faec845eb086a/pyright-1.1.396.tar.gz", hash = "sha256:142901f5908f5a0895be3d3befcc18bedcdb8cc1798deecaec86ef7233a29b03", size = 3814400 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/4c/50c74e3d589517a9712a61a26143b587dba6285434a17aebf2ce6b82d2c3/pyright-1.1.394-py3-none-any.whl", hash = "sha256:5f74cce0a795a295fb768759bbeeec62561215dea657edcaab48a932b031ddbb", size = 5679540 },
+    { url = "https://files.pythonhosted.org/packages/80/be/ecb7cfb42d242b7ee764b52e6ff4782beeec00e3b943a3ec832b281f9da6/pyright-1.1.396-py3-none-any.whl", hash = "sha256:c635e473095b9138c471abccca22b9fedbe63858e0b40d4fc4b67da041891844", size = 5689355 },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
 ## Why is this change necessary?
Pulumi Preview roles still need some write access to the S3 bucket.


 ## How does this change address the issue?
Updates the role for Central Infra, and also the bootstrap role in the organizational root account itself.


 ## What side effects does this change have?
the preview role has permissions to actually mutate things.


 ## How is this change tested?
Deployed in my AWS Organization


 ## Other
Updated some badges in readme, and moved the cloudformation to the instantiated template

Pulled in some updates from the base template

Added tags to resources in the cloudformation template