### PR TITLE
Remove hardcoded email address

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.5-62-gebf75db
+_commit: v0.0.6
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: Managing an AWS Organization
 python_ci_versions:

--- a/template/src/aws_organization/lib/account.py
+++ b/template/src/aws_organization/lib/account.py
@@ -12,6 +12,8 @@ from pulumi import export
 from pulumi.dynamic import CreateResult
 from pulumi_aws_native import organizations
 
+from ..constants import ACCOUNT_EMAIL_PREFIX
+
 logger = logging.getLogger(__name__)
 
 
@@ -37,7 +39,7 @@ class AwsAccount(ComponentResource):
             account_name,
             opts=ResourceOptions(parent=self),
             account_name=account_name,
-            email=f"ejfine+{account_name}@gmail.com",
+            email=f"{ACCOUNT_EMAIL_PREFIX}+{account_name}@gmail.com",
             parent_ids=[ou.id],
             # Deliberately not setting the role_name here, as it causes problems during any subsequent updates, even when not actually changing the role name. Could possible set up ignore_changes...but just leaving it out for now
             tags=common_tags_native(),


### PR DESCRIPTION
 ## Why is this change necessary?
There was a hardcoded email address in the code


 ## How does this change address the issue?
Uses the value from the copier questionaire


 ## What side effects does this change have?
None


 ## How is this change tested?
In a repo using this template
