### PR TITLE
Wait fully for account creation before creating a Provider

### DIFF
--- a/template/src/aws_organization/lib/central_infra_workload.py
+++ b/template/src/aws_organization/lib/central_infra_workload.py
@@ -47,9 +47,7 @@ def create_central_infra_workload(org_units: OrganizationalUnits) -> tuple[Commo
         assume_role=assume_role,
         allowed_account_ids=[central_infra_account.account.id],
         region="us-east-1",
-        opts=ResourceOptions(
-            parent=central_infra_account,
-        ),
+        opts=ResourceOptions(parent=central_infra_account, depends_on=central_infra_account.wait_after_account_create),
     )
     prod_account_data = [account.account_info_kwargs for account in [central_infra_account]]
     all_prod_accounts_resolved = Output.all(


### PR DESCRIPTION
 ## Why is this change necessary?
There was an issue when instantiating an Org where there was an odd error about a Role when trying to assume the Provider.  But when re-running the Pulumi Up after waiting a bit everything worked fine.


 ## How does this change address the issue?
Makes the Provider creation depend on the extra wait time after the central infra account is created


 ## What side effects does this change have?
Deployment may take slightly longer


 ## How is this change tested?
The new code has been deployed in a downstream repo...but it doesn't really test the root issue
