### PR TITLE
Create Billing Delegate Account

### DIFF
--- a/template/src/aws_organization/program.py
+++ b/template/src/aws_organization/program.py
@@ -6,6 +6,7 @@ from pulumi import ResourceOptions
 from pulumi import export
 from pulumi_aws.organizations import DelegatedAdministrator
 from pulumi_aws.organizations import DelegatedAdministratorArgs
+from pulumi_command.local import Command
 
 from .constants import CONFIGURE_CLOUD_COURIER
 from .lib import AwsWorkload
@@ -53,6 +54,11 @@ def pulumi_program() -> None:
         prod_account_name_suffixes=["prod"],
         **common_workload_kwargs,
     )
+    enable_billing_service_access = Command(  # I think this needs to be after at least 1 other account is created, but maybe not
+        "enable-aws-service-access-for-billing",
+        create="aws organizations enable-aws-service-access --service-principal cost-optimization-hub.bcm.amazonaws.com",
+        opts=ResourceOptions(depends_on=billing_delegate_workload.prod_accounts[0].wait_after_account_create),
+    )
     _ = DelegatedAdministrator(
         "delegate-billing-admin",
         DelegatedAdministratorArgs(
@@ -63,7 +69,7 @@ def pulumi_program() -> None:
             parent=billing_delegate_workload.prod_accounts[0],
             depends_on=[
                 billing_delegate_workload.prod_accounts[0].wait_after_account_create,
-                enable_service_access,
+                enable_billing_service_access,
             ],
         ),
     )


### PR DESCRIPTION
 ## Why is this change necessary?
The Identity Center delegate can't grant permissions to view management account


 ## How does this change address the issue?
Creates a billing delegate account so people can view billing


 ## What side effects does this change have?
New account


 ## How is this change tested?
My AWS Org

