### PR TITLE
Enable IAM Service Principal

### DIFF
--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -22,7 +22,8 @@ To create a new logical workload (a set of AWS accounts), add one in the `src/aw
 ## Using Pulumi
 Run a Pulumi Preview:
 ```bash
-uv run python -m aws_organization.lib.pulumi_deploy --stack={% endraw %}{{ pulumi_stack_name }}{% raw %}```
+uv run python -m aws_organization.lib.pulumi_deploy --stack={% endraw %}{{ pulumi_stack_name }}{% raw %}
+```
 
 ## Updating from the template
 This repository uses a copier template. To pull in the latest updates from the template, use the command:

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -20,7 +20,9 @@ To create a new logical workload (a set of AWS accounts), add one in the `src/aw
 # Development
 
 ## Using Pulumi
-Run a Pulumi Preview: `uv run python -m aws_organization.lib.pulumi_deploy --stack={% endraw %}{{ pulumi_stack_name }}{% raw %}`
+Run a Pulumi Preview:
+```bash
+uv run python -m aws_organization.lib.pulumi_deploy --stack={% endraw %}{{ pulumi_stack_name }}{% raw %}```
 
 ## Updating from the template
 This repository uses a copier template. To pull in the latest updates from the template, use the command:

--- a/template/src/aws_organization/lib/central_infra_workload.py
+++ b/template/src/aws_organization/lib/central_infra_workload.py
@@ -37,16 +37,25 @@ def create_central_infra_workload(org_units: OrganizationalUnits) -> tuple[Commo
         Command(  # I think this needs to be after at least 1 other account is created, but maybe not
             "enable-aws-service-access",
             create="aws organizations enable-aws-service-access --service-principal account.amazonaws.com",
+            delete="aws organizations disable-aws-service-access --service-principal account.amazonaws.com",
             opts=ResourceOptions(depends_on=central_infra_account.wait_after_account_create),
         )
     )
     # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-enable-root-access.html
+    enable_iam_service_access = (
+        Command(  # I think this needs to be after at least 1 other account is created, but maybe not
+            "enable-aws-service-access",
+            create="aws organizations enable-aws-service-access --service-principal iam.amazonaws.com",
+            delete="aws organizations disable-aws-service-access --service-principal iam.amazonaws.com",
+            opts=ResourceOptions(depends_on=enable_service_access),
+        )
+    )
     enable_root_creds_management = (
         Command(  # I think this needs to be after at least 1 other account is created, but maybe not
             "enable-root-creds-management",
             create="aws iam enable-organizations-root-credentials-management",
             delete="aws iam disable-organizations-root-credentials-management",
-            opts=ResourceOptions(depends_on=enable_service_access),
+            opts=ResourceOptions(depends_on=enable_iam_service_access),
         )
     )
     _ = Command(  # I think this needs to be after at least 1 other account is created, but maybe not

--- a/template/src/aws_organization/lib/central_infra_workload.py
+++ b/template/src/aws_organization/lib/central_infra_workload.py
@@ -44,7 +44,7 @@ def create_central_infra_workload(org_units: OrganizationalUnits) -> tuple[Commo
     # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-enable-root-access.html
     enable_iam_service_access = (
         Command(  # I think this needs to be after at least 1 other account is created, but maybe not
-            "enable-aws-service-access",
+            "enable-iam-service-access",
             create="aws organizations enable-aws-service-access --service-principal iam.amazonaws.com",
             delete="aws organizations disable-aws-service-access --service-principal iam.amazonaws.com",
             opts=ResourceOptions(depends_on=enable_service_access),

--- a/template/src/aws_organization/lib/central_infra_workload.py
+++ b/template/src/aws_organization/lib/central_infra_workload.py
@@ -38,7 +38,9 @@ def create_central_infra_workload(org_units: OrganizationalUnits) -> tuple[Commo
             "enable-aws-service-access",
             create="aws organizations enable-aws-service-access --service-principal account.amazonaws.com",
             delete="aws organizations disable-aws-service-access --service-principal account.amazonaws.com",
-            opts=ResourceOptions(depends_on=central_infra_account.wait_after_account_create),
+            opts=ResourceOptions(
+                depends_on=central_infra_account.wait_after_account_create, delete_before_replace=True
+            ),
         )
     )
     # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-enable-root-access.html
@@ -47,7 +49,7 @@ def create_central_infra_workload(org_units: OrganizationalUnits) -> tuple[Commo
             "enable-iam-service-access",
             create="aws organizations enable-aws-service-access --service-principal iam.amazonaws.com",
             delete="aws organizations disable-aws-service-access --service-principal iam.amazonaws.com",
-            opts=ResourceOptions(depends_on=enable_service_access),
+            opts=ResourceOptions(depends_on=enable_service_access, delete_before_replace=True),
         )
     )
     enable_root_creds_management = (
@@ -55,14 +57,14 @@ def create_central_infra_workload(org_units: OrganizationalUnits) -> tuple[Commo
             "enable-root-creds-management",
             create="aws iam enable-organizations-root-credentials-management",
             delete="aws iam disable-organizations-root-credentials-management",
-            opts=ResourceOptions(depends_on=enable_iam_service_access),
+            opts=ResourceOptions(depends_on=enable_iam_service_access, delete_before_replace=True),
         )
     )
     _ = Command(  # I think this needs to be after at least 1 other account is created, but maybe not
         "enable-organizations-root-sessions",
         create="aws iam enable-organizations-root-sessions",
         delete="aws iam disable-organizations-root-sessions",
-        opts=ResourceOptions(depends_on=enable_root_creds_management),
+        opts=ResourceOptions(depends_on=enable_root_creds_management, delete_before_replace=True),
     )
     central_infra_role_arn = central_infra_account.account.id.apply(
         lambda x: f"arn:aws:iam::{x}:role/{DEFAULT_ORG_ACCESS_ROLE_NAME}"


### PR DESCRIPTION
 ## Why is this change necessary?
Apparently this is a pre-requisite for root credentials management


 ## How does this change address the issue?
Adds command to enable it first


 ## What side effects does this change have?
None


 ## How is this change tested?
Downstream repo


 ## Other
Updated readme and added delete-before-replace for aws cli Commands