### PR TITLE
Fix preview role permissions

### DIFF
--- a/template/src/aws_organization/lib/central_infra_workload.py
+++ b/template/src/aws_organization/lib/central_infra_workload.py
@@ -264,12 +264,27 @@ def create_central_infra_workload(org_units: OrganizationalUnits) -> tuple[Commo
                 ),
                 policy_name="StateBucketWrite",
             ),
+            iam.RolePolicyArgs(
+                policy_document=get_policy_document(
+                    statements=[
+                        GetPolicyDocumentStatementArgs(
+                            sid="AssumePreviewRolesInOtherAccounts",
+                            effect="Allow",
+                            actions=["sts:AssumeRole"],
+                            resources=[f"arn:aws:iam::*:role/InfraPreview--{CENTRAL_INFRA_REPO_NAME}"],
+                        ),
+                    ]
+                ).json,
+                policy_name="AssumePreviewRolesInOtherAccounts",
+            ),
         ],
         tags=common_tags_native(),
         opts=ResourceOptions(provider=central_infra_provider, parent=central_infra_account),
     )
-    preview_in_workload_account_assume_role_policy = central_infra_preview_role.arn.apply(
-        lambda arn: get_policy_document(
+    preview_in_workload_account_assume_role_policy = Output.all(
+        central_infra_preview_role.arn, central_infra_account.account.account_id
+    ).apply(
+        lambda args: get_policy_document(
             statements=[
                 GetPolicyDocumentStatementArgs(
                     effect="Allow",
@@ -277,8 +292,11 @@ def create_central_infra_workload(org_units: OrganizationalUnits) -> tuple[Commo
                     principals=[
                         GetPolicyDocumentStatementPrincipalArgs(
                             type="AWS",
-                            identifiers=[arn],
-                        )
+                            identifiers=[
+                                args[0],
+                                f"arn:aws:iam::{args[1]}:root",  # TODO: consider locking this further down...but it's just a preview role, and it makes it so users can run previews when working in the central-infra repo
+                            ],
+                        ),
                     ],
                 )
             ]

--- a/template/src/aws_organization/lib/central_infra_workload.py
+++ b/template/src/aws_organization/lib/central_infra_workload.py
@@ -218,12 +218,7 @@ def create_central_infra_workload(org_units: OrganizationalUnits) -> tuple[Commo
                 GetPolicyDocumentStatementArgs(
                     effect="Allow",
                     actions=["sts:AssumeRole"],
-                    principals=[
-                        GetPolicyDocumentStatementPrincipalArgs(
-                            type="AWS",
-                            identifiers=[arn],
-                        )
-                    ],
+                    principals=[GetPolicyDocumentStatementPrincipalArgs(type="AWS", identifiers=[arn])],
                 )
             ]
         )


### PR DESCRIPTION
 ## Why is this change necessary?
The InfraPreview role in workload accounts couldn't be assumed by the Central Infra's own Preview role.

Also, developer ergonomics were bad for being able to run previews in the central-infra repo


 ## How does this change address the issue?
Grants the Infra Preview role the ability to assume Preview roles in workload accounts
Allows any IAM principal in the Central Infra account to assume the Preview Roles in the workload accounts


 ## What side effects does this change have?
Running previews works better.

Mild increase in security risk...but I couldn't figure out a way to use Wildcards to restrict it to specific SSO Roles that users assume


 ## How is this change tested?
in an AWS Org downstream repo

