### PR TITLE
Fix: github token preview permission

### DIFF
--- a/template/src/aws_organization/lib/central_infra_workload.py
+++ b/template/src/aws_organization/lib/central_infra_workload.py
@@ -269,7 +269,7 @@ def create_central_infra_workload(org_units: OrganizationalUnits) -> tuple[Commo
                                     "secretsmanager:GetSecretValue",
                                 ],
                                 resources=[
-                                    "arn:aws:secretsmanager:*:*:secret:/manually-entered-secrets/github-preview-access-token"  # TODO: lock down account and region
+                                    "arn:aws:secretsmanager:*:*:secret:/manually-entered-secrets/github-preview-access-token-*"  # TODO: lock down account and region
                                 ],  # TODO: move this secret path to shared library
                             ),
                         ]


### PR DESCRIPTION
 ## Why is this change necessary?
The ARN is actually longer than the secret name


 ## How does this change address the issue?
Add a `*` on the end of the ARN


 ## What side effects does this change have?
less restrictive permission


 ## How is this change tested?
isn't

