### PR TITLE
Fix issue with required check blocking merge

### DIFF
--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -118,4 +118,4 @@ jobs:
             -X POST -H "Accept: application/vnd.github.v3+json" \
             "/repos/${{ github.repository }}/statuses/${{ needs.get-values.outputs.new-dependabot-sha }}" \
             -f state=success -f context="required-check" -f description="Initial CI run passed" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"{% endraw %}

--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -116,7 +116,7 @@ jobs:
         run: |
           gh api \
             -X POST -H "Accept: application/vnd.github.v3+json" \
-            "/repos/${{ github.repository }}/statuses/${{ github.event.after }}" \
+            "${{ github.event.pull_request.statuses.href }}" \
             -f state=success -f context="required-check" -f description="✅ All required checks passed in the job triggered by pull_request" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 

--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -55,6 +55,7 @@ jobs:
     needs:
       - get-values
       - check-skip-duplicate
+      - lint
     if: needs.check-skip-duplicate.outputs.should-run == 'true'
     permissions:
       id-token: write # needed to assume OIDC roles (e.g. for downloading from CodeArtifact)

--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -109,15 +109,15 @@ jobs:
           fi
           echo "✅ All jobs completed successfully or were skipped"
 
-      - name: Mark required-check as succeeded
-        if: needs.check-skip-duplicate.outputs.should-run == 'true'
+      - name: Mark the required-check from the job triggered by the push as succeeded so the PR can be merged
+        if: ${{ github.event_name == 'pull_request' && needs.check-skip-duplicate.outputs.should-run == 'true'}}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh api \
             -X POST -H "Accept: application/vnd.github.v3+json" \
-            "/repos/${{ github.repository }}/statuses/${{ github.sha }}" \
-            -f state=success -f context="required-check" -f description="✅ All required checks passed" \
+            "/repos/${{ github.repository }}/statuses/${{ github.event.after }}" \
+            -f state=success -f context="required-check" -f description="✅ All required checks passed in the job triggered by pull_request" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Mark updated Dependabot commit of devcontainer hash as succeeded

--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -73,7 +73,7 @@ jobs:
       AWS_ACCOUNT_ID: "{% endraw %}{{ aws_production_account_id }}{% raw %}"
       SHOW_PREVIEW_COMMENT_ON_PR: ${{ github.event_name == 'pull_request' }}
 
-  required-check:
+  workflow-summary:
     runs-on: {% endraw %}{{ gha_linux_runner }}{% raw %}
     timeout-minutes: {% endraw %}{{ gha_short_timeout_minutes }}{% raw %}
     needs:
@@ -82,21 +82,9 @@ jobs:
       - check-skip-duplicate
       - pulumi-workflow
     permissions:
-      statuses: write # needed for updating status on Dependabot PRs
+      statuses: write # needed for updating status on PRs
     if: always()
     steps:
-      - name: Set status for duplicate detection
-        if: needs.check-skip-duplicate.outputs.should-run != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh api \
-            -X POST -H "Accept: application/vnd.github.v3+json" \
-            "/repos/${{ github.repository }}/statuses/${{ github.sha }}" \
-            -f state=pending -f context="required-check" -f description="⏭️ Workflow skipped due to duplicate detection"
-          echo "⏭️ Workflow was skipped due to duplicate detection - status set to pending to block merge"
-          exit 0
-
       - name: fail if prior job failure
         run: |
           failure_pattern="^(failure|cancelled)$"
@@ -117,7 +105,7 @@ jobs:
         run: |
           gh api \
             -X POST -H "Accept: application/vnd.github.v3+json" \
-            "${{ github.event.pull_request._links.statuses.href }}" \
+            "${{ github.event.pull_request.statuses_url }}" \
             -f state=success -f context="required-check" -f description="✅ All required checks passed in the job triggered by pull_request" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
@@ -130,4 +118,4 @@ jobs:
             -X POST -H "Accept: application/vnd.github.v3+json" \
             "/repos/${{ github.repository }}/statuses/${{ needs.get-values.outputs.new-dependabot-sha }}" \
             -f state=success -f context="required-check" -f description="Initial CI run passed" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"{% endraw %}
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -98,7 +98,7 @@ jobs:
           fi
           echo "✅ All jobs completed successfully or were skipped"
 
-      - name: Mark the required-check from the job triggered by the push as succeeded so the PR can be merged
+      - name: Mark the required-check as succeeded so the PR can be merged
         if: ${{ github.event_name == 'pull_request' }}
         env:
           GH_TOKEN: ${{ github.token }}

--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -99,7 +99,7 @@ jobs:
           echo "✅ All jobs completed successfully or were skipped"
 
       - name: Mark the required-check from the job triggered by the push as succeeded so the PR can be merged
-        if: ${{ github.event_name == 'pull_request' && needs.check-skip-duplicate.outputs.should-run == 'true'}}
+        if: ${{ github.event_name == 'pull_request' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -116,7 +116,7 @@ jobs:
         run: |
           gh api \
             -X POST -H "Accept: application/vnd.github.v3+json" \
-            "${{ github.event.pull_request.statuses.href }}" \
+            "${{ github.event.pull_request._links.statuses.href }}" \
             -f state=success -f context="required-check" -f description="✅ All required checks passed in the job triggered by pull_request" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 


### PR DESCRIPTION
 ## Why is this change necessary?
The previous approach didn't allow merges, because the manually created "processing" status still blocked the merge even after the attempted explicit "success" API call


 ## How does this change address the issue?
change the name of the CI job so it doesn't match the needed status, and have the pull_request job explicitly set the `required-check` status to "success"


 ## What side effects does this change have?
N/A


 ## How is this change tested?
https://github.com/ejfine/aws-organization/pull/30

pushing commits with an open PR.  opening a PR after a successful commit run had finished. closing and reopening PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed and clarified CI job flow; broadened its conditions to run for pull requests.
  * Ensured lint runs earlier in the CI sequence.
  * Removed the duplicate-detection status step.
  * Updated final status updates to use the pull-request statuses endpoint, use a consistent run identifier for the target URL, and fixed an extraneous character in the Dependabot status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->