### PR TITLE
Refresh workflow permissions, and require explicit break glass setting for Org Admin access

### DIFF
--- a/template/.github/workflows/refresh-stack.yaml.jinja
+++ b/template/.github/workflows/refresh-stack.yaml.jinja
@@ -26,6 +26,7 @@ jobs:
     permissions:
       id-token: write # needed to assume OIDC roles (e.g. for downloading from CodeArtifact)
       contents: write # needed for mutex
+      pull-requests: write # needed to potentially post the preview on the PR as a comment
     with:
       AWS_REGION: {% endraw %}{{ aws_region_for_stack }}{% raw %}
       PULUMI_STACK_NAME: {% endraw %}{{ pulumi_stack_name }}{% raw %}
@@ -43,6 +44,7 @@ jobs:
     permissions:
       id-token: write # needed to assume OIDC roles (e.g. for downloading from CodeArtifact)
       contents: write # needed for mutex
+      pull-requests: write # needed to potentially post the preview on the PR as a comment
     with:
       AWS_REGION: {% endraw %}{{ aws_region_for_stack }}{% raw %}
       PULUMI_STACK_NAME: {% endraw %}{{ pulumi_stack_name }}{% raw %}

--- a/template/src/aws_organization/lib/__init__.py
+++ b/template/src/aws_organization/lib/__init__.py
@@ -2,6 +2,7 @@ from .account import AwsAccount
 from .central_infra_workload import create_central_infra_workload
 from .org_units import OrganizationalUnits
 from .org_units import create_organizational_units
+from .program import OrgAdmin
 from .workload import DEFAULT_ORG_ACCESS_ROLE_NAME
 from .workload import AwsWorkload
 from .workload import CommonWorkloadKwargs

--- a/template/src/aws_organization/lib/__init__.py
+++ b/template/src/aws_organization/lib/__init__.py
@@ -2,7 +2,6 @@ from .account import AwsAccount
 from .central_infra_workload import create_central_infra_workload
 from .org_units import OrganizationalUnits
 from .org_units import create_organizational_units
-from .program import OrgAdmin
 from .workload import DEFAULT_ORG_ACCESS_ROLE_NAME
 from .workload import AwsWorkload
 from .workload import CommonWorkloadKwargs

--- a/template/src/aws_organization/lib/program.py
+++ b/template/src/aws_organization/lib/program.py
@@ -5,11 +5,13 @@ from ephemeral_pulumi_deploy import get_config
 from lab_auto_pulumi import AwsAccountInfo
 from lab_auto_pulumi import AwsSsoPermissionSet
 from lab_auto_pulumi import AwsSsoPermissionSetAccountAssignments
+from lab_auto_pulumi import UserInfo
 from pulumi import ResourceOptions
 from pulumi import export
 from pulumi_aws.organizations import DelegatedAdministrator
 from pulumi_aws.organizations import DelegatedAdministratorArgs
 from pulumi_command.local import Command
+from pydantic import BaseModel
 
 from ..org_management import get_org_admins
 from ..workloads import create_workloads
@@ -19,6 +21,11 @@ from .org_units import create_organizational_units
 from .workload import AwsWorkload
 
 logger = logging.getLogger(__name__)
+
+
+class OrgAdmin(BaseModel):
+    user_info: UserInfo
+    enable_break_glass_access: bool = False
 
 
 def pulumi_program() -> None:
@@ -50,12 +57,16 @@ def pulumi_program() -> None:
     )
     management_account_info = AwsAccountInfo(name="management-account", id=get_aws_account_id())
     org_admins = get_org_admins()
-    for perm_set in (org_admin_access, org_admin_view_access):
-        _ = AwsSsoPermissionSetAccountAssignments(
-            permission_set=perm_set,
-            users=org_admins,
-            account_info=management_account_info,
-        )
+    _ = AwsSsoPermissionSetAccountAssignments(
+        permission_set=org_admin_view_access,
+        users=[admin.user_info for admin in org_admins],
+        account_info=management_account_info,
+    )
+    _ = AwsSsoPermissionSetAccountAssignments(
+        permission_set=org_admin_access,
+        users=[admin.user_info for admin in org_admins if admin.enable_break_glass_access],
+        account_info=management_account_info,
+    )
 
     common_workload_kwargs, enable_service_access = create_central_infra_workload(org_units)
     identity_center_delegate_workload = AwsWorkload(

--- a/template/src/aws_organization/lib/program.py
+++ b/template/src/aws_organization/lib/program.py
@@ -5,13 +5,11 @@ from ephemeral_pulumi_deploy import get_config
 from lab_auto_pulumi import AwsAccountInfo
 from lab_auto_pulumi import AwsSsoPermissionSet
 from lab_auto_pulumi import AwsSsoPermissionSetAccountAssignments
-from lab_auto_pulumi import UserInfo
 from pulumi import ResourceOptions
 from pulumi import export
 from pulumi_aws.organizations import DelegatedAdministrator
 from pulumi_aws.organizations import DelegatedAdministratorArgs
 from pulumi_command.local import Command
-from pydantic import BaseModel
 
 from ..org_management import get_org_admins
 from ..workloads import create_workloads
@@ -21,11 +19,6 @@ from .org_units import create_organizational_units
 from .workload import AwsWorkload
 
 logger = logging.getLogger(__name__)
-
-
-class OrgAdmin(BaseModel):
-    user_info: UserInfo
-    enable_break_glass_access: bool = False
 
 
 def pulumi_program() -> None:

--- a/template/src/aws_organization/org_management.py
+++ b/template/src/aws_organization/org_management.py
@@ -1,6 +1,18 @@
-from lab_auto_pulumi import UserInfo
+from lab_auto_pulumi import UserInfo  # noqa: F401 # remove this noqa when first used
+
+from .lib import OrgAdmin
 
 
-def get_org_admins() -> list[UserInfo]:
-    org_admins: list[UserInfo] = []
+def get_org_admins() -> list[OrgAdmin]:
+    """Define Admins.
+
+    Example:
+    ```
+    org_admins: list[OrgAdmin] = [
+        OrgAdmin(user_info=UserInfo(username="eli.fine@lab-sync.com"), enable_break_glass_access=False),
+        OrgAdmin(user_info=UserInfo(username="mal.reynolds@firefly.star")),
+    ]
+    ```
+    """
+    org_admins: list[OrgAdmin] = []
     return org_admins

--- a/template/src/aws_organization/org_management.py
+++ b/template/src/aws_organization/org_management.py
@@ -1,6 +1,10 @@
-from lab_auto_pulumi import UserInfo  # noqa: F401 # remove this noqa when first used
+from lab_auto_pulumi import UserInfo
+from pydantic import BaseModel
 
-from .lib import OrgAdmin
+
+class OrgAdmin(BaseModel):
+    user_info: UserInfo
+    enable_break_glass_access: bool = False
 
 
 def get_org_admins() -> list[OrgAdmin]:
@@ -9,7 +13,7 @@ def get_org_admins() -> list[OrgAdmin]:
     Example:
     ```
     org_admins: list[OrgAdmin] = [
-        OrgAdmin(user_info=UserInfo(username="eli.fine@lab-sync.com"), enable_break_glass_access=False),
+        OrgAdmin(user_info=UserInfo(username="eli.fine@elifine.com"), enable_break_glass_access=False),
         OrgAdmin(user_info=UserInfo(username="mal.reynolds@firefly.star")),
     ]
     ```


### PR DESCRIPTION
## Why is this change necessary?
New way of commenting on PRs requires additional permissions for Pulumi-Aws workflow (in refresh workflow.yml).

It's not good to automatically have breakglass access in management account


## How does this change address the issue?
Adds workflow perms

Adds separate pydantic model to be able to specify whether org admins should have admin access (or just view access)


## What side effects does this change have?
N/A


## How is this change tested?
Downstream repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced granular permission control for organization admins. Admin-level access now requires explicit break glass access enablement, while view-level access remains available to all organization admins, providing enhanced security controls.

* **Chores**
  * Updated GitHub Actions workflow permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->